### PR TITLE
Add new syntax char

### DIFF
--- a/abap-mode.el
+++ b/abap-mode.el
@@ -396,6 +396,7 @@
   (modify-syntax-entry ?_  "w")
   (modify-syntax-entry ?-  "w")
   (modify-syntax-entry ?|  "\"")
+  (modify-syntax-entry ?\\ "\"")
   ;; Comment Style of Staring with "
   (modify-syntax-entry ?\" "<")
   (modify-syntax-entry ?\n ">")

--- a/abap-mode.el
+++ b/abap-mode.el
@@ -395,8 +395,8 @@
   (modify-syntax-entry ?' "\"")
   (modify-syntax-entry ?_  "w")
   (modify-syntax-entry ?-  "w")
+  (modify-syntax-entry ?\\ "w")
   (modify-syntax-entry ?|  "\"")
-  (modify-syntax-entry ?\\ "\"")
   ;; Comment Style of Staring with "
   (modify-syntax-entry ?\" "<")
   (modify-syntax-entry ?\n ">")


### PR DESCRIPTION
I  add a syntax char '¥' (Windows back slash).
Once input '¥' on abap-mode, syntax parser will failure.